### PR TITLE
Fix mediaElementSource CORS errors

### DIFF
--- a/src/js/audio/actor.js
+++ b/src/js/audio/actor.js
@@ -32,14 +32,8 @@ export default class Actor {
       position.z
     );
 
-    this.audioStream.src = url;
-    this.audioStream.play();
-
-    // Hack to avoid "MediaElementAudioSource outputs zeroes
-    // due to CORS access restrictions"
-    setTimeout(() => {
-      this.audioStream.connect(this.resonanceSource.input);
-    }, 10);
+    this.audioStream.connect(this.resonanceSource.input);
+    this.audioStream.start(url);
   }
 
   stop() {
@@ -47,6 +41,5 @@ export default class Actor {
 
     this.audioStream.stop();
     this.audioStream.disconnect();
-    this.audioStream.src = null;
   }
 }

--- a/src/js/audio/audio-stream.js
+++ b/src/js/audio/audio-stream.js
@@ -12,41 +12,43 @@ export default class AudioStream extends AudioBase {
   constructor(context) {
     super(context);
 
+    this.output = context.createGain();
+    this.isPlaying = false;
+  }
+
+  createNodes() {
     this.audioTag = document.createElement('audio');
     this.audioTag.controls = false;
     this.audioTag.crossOrigin = 'anonymous';
     this.audioTag.loop = true;
-    this.audioTag.preload = 'none';
-    this.audioTag.src = null;
 
     this.audioNode = this.context.createMediaElementSource(this.audioTag);
-
-    this.isPlaying = false;
+    this.audioNode.connect(this.output);
   }
 
-  set src(url) {
-    this.audioTag.src = url;
-  }
-
-  get src() {
-    return this.audioTag.src;
-  }
-
-  connect(aNode) {
-    this.audioNode.connect(aNode);
-  }
-
-  disconnect() {
+  removeNodes() {
+    this.audioTag.remove();
     this.audioNode.disconnect();
   }
 
-  play() {
+  connect(node) {
+    this.output.connect(node);
+  }
+
+  disconnect() {
+    this.output.disconnect();
+  }
+
+  start(url) {
     if (this.isPlaying) {
       return;
     }
 
     this.isPlaying = true;
 
+    this.createNodes();
+
+    this.audioTag.src = url;
     this.audioTag.play();
   }
 
@@ -59,5 +61,7 @@ export default class AudioStream extends AudioBase {
 
     this.audioTag.pause();
     this.audioTag.currentTime = 0;
+
+    this.removeNodes();
   }
 }

--- a/src/js/audio/audio-stream.js
+++ b/src/js/audio/audio-stream.js
@@ -14,6 +14,7 @@ export default class AudioStream extends AudioBase {
 
     this.output = context.createGain();
     this.isPlaying = false;
+    this.canPause = false;
   }
 
   createNodes() {
@@ -49,7 +50,15 @@ export default class AudioStream extends AudioBase {
     this.createNodes();
 
     this.audioTag.src = url;
-    this.audioTag.play();
+    const playPromise = this.audioTag.play();
+
+    if (playPromise !== undefined) {
+      playPromise.then(() => {
+        this.canPause = true;
+      });
+    } else {
+      this.canPause = true;
+    }
   }
 
   stop() {
@@ -57,11 +66,14 @@ export default class AudioStream extends AudioBase {
       return;
     }
 
+    if (this.canPause) {
+      this.audioTag.pause();
+      this.audioTag.currentTime = 0;
+
+      this.removeNodes();
+    }
+
     this.isPlaying = false;
-
-    this.audioTag.pause();
-    this.audioTag.currentTime = 0;
-
-    this.removeNodes();
+    this.canPause = false;
   }
 }


### PR DESCRIPTION
The reason for the CORS errors that we've been seeing was triggered when changing the src attribute of an audio DOM element while still connected to a mediaElementSource audio node.
 
This change creates/removes audio tags on whenever starting playback of an actor, let's see if it is performant enough.. it seems to work well on my X200 so far :)